### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,7 @@ jobs:
       run: docker build . --file Dockerfile --tag eibayan/mygo:$(date +%s)
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       if: github.ref == 'refs/heads/main'
       with:
         name: eibayan/mygo


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore